### PR TITLE
ASU-269 | Increase key length

### DIFF
--- a/django_oikotie/xml_models/apartment.py
+++ b/django_oikotie/xml_models/apartment.py
@@ -1060,7 +1060,7 @@ class Apartment(XMLModel):
         attributes = ["action", "type", "new_houses", "new_apartment_reserved"]
 
     def format_key(self) -> str:
-        return self.key[:30]
+        return self.key[:100]
 
     def format_vendor_identifier(self) -> str:
         return self.vendor_identifier[:40]
@@ -1153,7 +1153,7 @@ class Apartment(XMLModel):
         return self.housing_company_name[:100]
 
     def format_housing_company_key(self) -> str:
-        return self.housing_company_key[:30]
+        return self.housing_company_key[:2000]
 
     def format_business_id(self) -> str:
         return self.business_id[:12]

--- a/django_oikotie/xml_models/housing_company.py
+++ b/django_oikotie/xml_models/housing_company.py
@@ -28,9 +28,7 @@ class _BasePicture(XMLModel):
         if timestamp_formatted:
             kwargs["timestamp"] = timestamp_formatted
 
-        element = etree.Element(
-            self.Meta.element_name, **kwargs
-        )
+        element = etree.Element(self.Meta.element_name, **kwargs)
         element.text = self.format_image_url()
         return element
 
@@ -218,7 +216,7 @@ class HousingCompany(XMLModel):
         case = Case.KEBAB
 
     def format_key(self) -> str:
-        return self.key[:30]
+        return self.key[:100]
 
     def format_name(self) -> str:
         return self.name[:100]


### PR DESCRIPTION
Oikotie agreed to increase the max length of the `key` and `housing_company_key` because we are using uuid4, which is over 30 characters long.

Refs ASU-269